### PR TITLE
Add the option of a new reference id to the new statement

### DIFF
--- a/src/Bll/StatementBLL.php
+++ b/src/Bll/StatementBLL.php
@@ -354,7 +354,8 @@ class StatementBLL
 
     /**
      * @param int $statementId
-     * @param StatementDTO|null $statementDto
+     * @param StatementDTO $statementDtoWithdraw
+     * @param StatementDTO $statementDtoRefund
      * @return int|null
      * @throws AccountException
      * @throws AmountException
@@ -366,12 +367,8 @@ class StatementBLL
      * @throws UpdateConstraintException
      * @throws \ByJG\MicroOrm\Exception\InvalidArgumentException
      */
-    public function acceptPartialFundsById(int $statementId, ?StatementDTO $statementDtoWithdraw, ?StatementDTO $statementDtoRefund): ?int
+    public function acceptPartialFundsById(int $statementId, StatementDTO $statementDtoWithdraw, StatementDTO $statementDtoRefund): ?int
     {
-        if (is_null($statementDtoWithdraw) || is_null($statementDtoRefund)) {
-            throw new StatementException('acceptPartialFundsById: StatementDTO cannot be null.');
-        }
-
         $partialAmount = $statementDtoWithdraw->getAmount();
 
         if ($partialAmount <= 0) {

--- a/src/Bll/StatementBLL.php
+++ b/src/Bll/StatementBLL.php
@@ -17,6 +17,7 @@ use ByJG\MicroOrm\Exception\RepositoryReadOnlyException;
 use ByJG\MicroOrm\Exception\UpdateConstraintException;
 use ByJG\Serializer\Exception\InvalidArgumentException;
 use Exception;
+use KingPandaApi\Model\StatementCodes;
 
 class StatementBLL
 {
@@ -365,7 +366,7 @@ class StatementBLL
      * @throws UpdateConstraintException
      * @throws \ByJG\MicroOrm\Exception\InvalidArgumentException
      */
-    public function acceptPartialFundsById(int $statementId, ?StatementDTO $statementDto): ?int
+    public function acceptPartialFundsById(int $statementId, ?StatementDTO $statementDto, ?string $referenceId = null): ?int
     {
         if (is_null($statementDto)) {
             throw new StatementException('acceptPartialFundsById: StatementDTO cannot be null.');
@@ -397,7 +398,12 @@ class StatementBLL
                 );
             }
 
-            $this->rejectFundsById($statementId, StatementDTO::createEmpty()->setDescription('Reversal of partial acceptance for reserve ' . $statementId));
+            $this->rejectFundsById($statementId,
+                StatementDTO::createEmpty()
+                    ->setDescription('Refund for initial bet ' . $statementId)
+                    ->setCode('REFUND')
+                    ->setReferenceId($referenceId ?? $statementDto->getReferenceId())
+            );
 
             $statementDto->setAccountId($statement->getAccountId());
 

--- a/tests/Database/ReserveFundsDepositTest.php
+++ b/tests/Database/ReserveFundsDepositTest.php
@@ -218,7 +218,11 @@ public function testAcceptFundsById_InvalidType()
             StatementDTO::create($accountId, 100)
         );
 
-        $this->statementBLL->acceptPartialFundsById($reserveStatementId, null);
+        $statementRefundDto = StatementDTO::createEmpty()
+            ->setDescription("Refund")
+            ->setReferenceSource("test-source");
+
+        $this->statementBLL->acceptPartialFundsById($reserveStatementId, null, $statementRefundDto);
     }
 
     public function testAcceptPartialFundsById_PartialAmountZero()
@@ -230,8 +234,12 @@ public function testAcceptFundsById_InvalidType()
             StatementDTO::create($accountId, 100)
         );
 
+        $statementRefundDto = StatementDTO::createEmpty()
+            ->setDescription("Refund")
+            ->setReferenceSource("test-source");
+
         $statementDTO = StatementDTO::createEmpty()->setAmount(0);
-        $this->statementBLL->acceptPartialFundsById($reserveStatementId, $statementDTO);
+        $this->statementBLL->acceptPartialFundsById($reserveStatementId, $statementDTO, $statementRefundDto);
     }
 
     public function testAcceptPartialFundsById_AmountMoreThanWithdrawBlocked()
@@ -244,8 +252,12 @@ public function testAcceptFundsById_InvalidType()
             StatementDTO::create($accountId, 100)
         );
 
+        $statementRefundDto = StatementDTO::createEmpty()
+            ->setDescription("Refund")
+            ->setReferenceSource("test-source");
+
         $statementDTO = StatementDTO::createEmpty()->setAmount(100.01);
-        $this->statementBLL->acceptPartialFundsById($reserveStatementId, $statementDTO);
+        $this->statementBLL->acceptPartialFundsById($reserveStatementId, $statementDTO, $statementRefundDto);
     }
 
     public function testAcceptPartialFundsById_OK()
@@ -255,15 +267,19 @@ public function testAcceptFundsById_InvalidType()
             StatementDTO::create($accountId, 100)->setDescription('Reserva para Aposta')
         );
 
-        $statementDTO = StatementDTO::createEmpty()
+        $statementWithdrawDto = StatementDTO::createEmpty()
             ->setAmount(80.00)
             ->setDescription("Deposit")
-            ->setReferenceSource("test-source")
-            ->setReferenceId('2');
+            ->setReferenceSource("test-source");
+
+        $statementRefundDto = StatementDTO::createEmpty()
+            ->setDescription("Refund")
+            ->setReferenceSource("test-source");
 
         $finalDebitStatementId = $this->statementBLL->acceptPartialFundsById(
             $reserveStatementId,
-            $statementDTO
+            $statementWithdrawDto,
+            $statementRefundDto
         );
 
         $accountAfter = $this->accountBLL->getById($accountId);

--- a/tests/Database/ReserveFundsDepositTest.php
+++ b/tests/Database/ReserveFundsDepositTest.php
@@ -258,7 +258,8 @@ public function testAcceptFundsById_InvalidType()
         $statementDTO = StatementDTO::createEmpty()
             ->setAmount(80.00)
             ->setDescription("Deposit")
-            ->setReferenceSource("test-source");
+            ->setReferenceSource("test-source")
+            ->setReferenceId('2');
 
         $finalDebitStatementId = $this->statementBLL->acceptPartialFundsById(
             $reserveStatementId,

--- a/tests/Database/ReserveFundsDepositTest.php
+++ b/tests/Database/ReserveFundsDepositTest.php
@@ -209,22 +209,6 @@ public function testAcceptFundsById_InvalidType()
         $this->assertEquals($statement->toArray(), $actual->toArray());
     }
 
-    public function testAcceptPartialFundsById_StatementDTONull()
-    {
-        $this->expectException(StatementException::class);
-
-        $accountId = $this->accountBLL->createAccount('USDTEST', "___TESTUSER-1", 1000);
-        $reserveStatementId = $this->statementBLL->reserveFundsForWithdraw(
-            StatementDTO::create($accountId, 100)
-        );
-
-        $statementRefundDto = StatementDTO::createEmpty()
-            ->setDescription("Refund")
-            ->setReferenceSource("test-source");
-
-        $this->statementBLL->acceptPartialFundsById($reserveStatementId, null, $statementRefundDto);
-    }
-
     public function testAcceptPartialFundsById_PartialAmountZero()
     {
         $this->expectException(AmountException::class);


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Introduce an option to use distinct `StatementDTO` objects for withdrawal and refund operations in the `acceptPartialFundsById` method, requiring both `StatementDTO` for the withdrawal and refund instead of a single nullable `StatementDTO`.

### Why are these changes being made?

This modification improves the robustness and clarity of transaction operations by eliminating the risk associated with nullable objects and providing explicit `StatementDTO` for different transaction purposes (withdrawal and refund). This ensures accurate handling of transaction details and aids future maintenance by making the code intentions clearer.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->